### PR TITLE
Add tests for attachment and todo presenter

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,0 +1,25 @@
+class Attachment
+  MS_OFFICE_TYPES = [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/msword",
+    "application/vnd.ms-excel",
+    "application/vnd.ms-powerpoint"
+  ].freeze
+
+  attr_reader :attachment_content_type, :locked_until
+
+  def initialize(attachment_content_type, locked_until = nil)
+    @attachment_content_type = attachment_content_type
+    @locked_until = locked_until
+  end
+
+  def editable?
+    MS_OFFICE_TYPES.include?(attachment_content_type)
+  end
+
+  def locked?
+    locked_until && locked_until > Time.zone.now
+  end
+end

--- a/app/presenters/todo_presenter.rb
+++ b/app/presenters/todo_presenter.rb
@@ -1,0 +1,29 @@
+class TodoPresenter
+  MAX_TAGS_ALLOWED = 4
+
+  attr_reader :todo
+
+  def initialize(todo)
+    @todo = todo
+  end
+
+  def display_text
+    return todo.title unless todo.tags.any?
+
+    todo_title_with_tags(todo)
+  end
+
+  private
+
+  def todo_title_with_tags(todo)
+    if (1..MAX_TAGS_ALLOWED).cover? todo.tags.count
+      [todo.title, tags_list(todo.tags)].join(" ")
+    else
+      [todo.title, tags_list(todo.tags.first(MAX_TAGS_ALLOWED)), "and more..."].join(" ")
+    end
+  end
+
+  def tags_list(tags)
+    tags.join(", ")
+  end
+end

--- a/spec/factories/todos.rb
+++ b/spec/factories/todos.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :todo do
+    title { Faker::Book.title }
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe Attachment do
+  describe "#editable?" do
+    context "when attachment has permitted type" do
+      subject(:attachment) { described_class.new(Attachment::MS_OFFICE_TYPES.sample) }
+
+      it { is_expected.to be_editable }
+    end
+
+    context "when attachment has non-permitted type" do
+      subject(:attachment) { described_class.new("application/zip") }
+
+      it { is_expected.not_to be_editable }
+    end
+  end
+
+  describe "#locked?" do
+    context "when locked_until attribute is not defined" do
+      subject(:attachment) { described_class.new("application/msword") }
+
+      it { is_expected.not_to be_locked }
+    end
+
+    context "when locked_until attribute is in past" do
+      subject(:attachment) { described_class.new("application/msword", 1.minute.ago) }
+
+      it { is_expected.not_to be_locked }
+    end
+
+    context "when locked_until attribute is equal to current time" do
+      before do
+        travel_to Time.zone.local(2020, 1, 8)
+      end
+
+      after do
+        travel_back
+      end
+
+      subject(:attachment) { described_class.new("application/msword", Time.zone.local(2020, 1, 8)) }
+
+      it { is_expected.not_to be_locked }
+    end
+
+    context "when locked_until attribute is in future" do
+      subject(:attachment) { described_class.new("application/msword", 1.minute.from_now) }
+
+      it { is_expected.to be_locked }
+    end
+  end
+end

--- a/spec/presenters/todo_presenter_spec.rb
+++ b/spec/presenters/todo_presenter_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe TodoPresenter do
+  describe "#display_text" do
+    context "when Todo hasn't tags" do
+      let(:todo) { build_stubbed(:todo, title: todo_title) }
+      let(:todo_title) { "Todo title" }
+
+      subject(:todo_text) { described_class.new(todo).display_text }
+
+      it { is_expected.to eq(todo_title) }
+    end
+
+    context "when Todo has tags" do
+      let(:todo) { build_stubbed(:todo, title: "Todo title", tags: ["todo_tag", "some_tag"]) }
+      let(:title_with_tags) { "Todo title todo_tag, some_tag" }
+
+      subject(:todo_text) { described_class.new(todo).display_text }
+
+      it { is_expected.to eq(title_with_tags) }
+    end
+
+    context "when Todo has tags number more than allowed" do
+      let(:todo) do
+        build_stubbed(:todo, title: "Todo title", tags: ["first", "second", "third", "fourth", "fifth"])
+      end
+      let(:title_with_first_allowed_tags) { "Todo title first, second, third, fourth and_more..." }
+
+      subject(:todo_text) { described_class.new(todo).display_text }
+
+      it { is_expected.to eq(title_with_first_allowed_tags) }
+    end
+  end
+end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
# Practice "Correct, wrong and edge cases"

This adds tests for `Attachment` and `TodoPresenter` classes
